### PR TITLE
feat: Support modifying responses before caching

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,7 @@
-export { type CacheOptions, SnapStorage } from "./src/snap_storage.ts";
+export {
+  type CacheOptions,
+  type ResponseMutator,
+  SnapStorage,
+} from "./src/snap_storage.ts";
 
 export { type Policy, type SnapMeta, type Snapshot } from "./src/snapshot.ts";

--- a/src/snap_storage.test.ts
+++ b/src/snap_storage.test.ts
@@ -120,4 +120,19 @@ describe("Snapshot storage", () => {
 
     assert(!storedSnap.isFresh, "Existing snapshots should not be fresh");
   });
+
+  it("caches a modified fetched JSON response", async () => {
+    const url = toFileUrl(resolve("README.md"));
+    async function responseMutator(response: Response) {
+      await response.text();
+
+      return new Response(JSON.stringify({ mutation: true }), response);
+    }
+    const fetchedSnap = await snaps.cache(url, {
+      responseMutator: responseMutator,
+    });
+    const fetchedJSON = await fetchedSnap.content.json();
+
+    assert(fetchedJSON.mutation, "JSON response was not mutated");
+  });
 });


### PR DESCRIPTION
This commit adds support for passing a mutator function as an argument to cache. The primary use case is making requests to non-API URLs where the response may contain large amounts of dynamic and/or superflous data.